### PR TITLE
config issues in django.dev.dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
+.gitignore
+
 .vscode/
+.idea
+
+*.pyc
+__pycache__
+.ipynb_checkpoints
+
 __pycache__/
 datasets/
 staticfiles/

--- a/deployment/django.dev.dockerfile
+++ b/deployment/django.dev.dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.3.0-base-ubuntu20.04
+FROM nvidia/cuda:11.3.1-base-ubuntu20.04
 
 ENV TZ=Europe/Zagreb
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -8,7 +8,7 @@ ENV PYTHONUNBUFFERED 1
 
 RUN apt update && apt install -y python3-dev libpq-dev
 RUN apt-get update && apt-get install -y python3.8 python3-pip
-RUN pip install --upgrade pip
+RUN pip install pip==23.3.2
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt


### PR DESCRIPTION
The .gitignore commit is to be ignored

The [django.dev.dockerfile] commit contains two corrections that enable the dev version of the app to run:

1. nvidia/cuda:11.3.0-base-ubuntu20.04 does not exists anymore, 
replaced it with closest new version: nvidia/cuda:11.3.1-base-ubuntu20.04
    
3. pip >=24.1 (current version to which the pip is upgraded automatically) 
does not support (<dev) version syntax found in the metadata of celery 5.0.5
therefore "RUN pip install --upgrade pip" replaced with "RUN pip install pip==23.3.2", as this version will install all the requirements without problems, otherwise the requirement.txt install fails
